### PR TITLE
SAAS-1450: Support Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "illuminate/support": "^10.0|^11.0|^12.0"
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "orchestra/testbench": "^8.0|^9.0",


### PR DESCRIPTION
## Summary

- allow `gregpriday/laravel-retry` to resolve with `illuminate/support:^13.0`
- keep Laravel 10, 11, and 12 compatibility unchanged
- preserve the fork existing tests and formatting exactly

## Why

Foresight Laravel 13 dependency solve is blocked transitively by this package upper bound. The upstream package is inactive for our delivery timeline, so Lula needs a history-preserving fork release.

Linear: [SAAS-1450](https://linear.app/lulalife/issue/SAAS-1450/upgrade-foresight-to-laravel-13-and-pest-5)

## Validation

- `composer validate --strict --no-check-publish --no-check-lock`: passed
- Foresight integration: Laravel 13.25.0 resolves and exercises this fork during the 23k-test backend run
- Existing package suite does not complete on the unchanged Lula fork baseline because `HttpClientIntegrationTest` exceeds the repository five-second PHP execution limit
- Existing `composer format:test` reports inherited formatting debt across source and tests

No baseline package tests or formatting were changed for this compatibility PR.

## Release

After approval, tag a Lula-owned `0.2.1` release. Foresight must consume the tag rather than a local path repository.

## Rollback

This only broadens a constraint. Laravel 10-12 consumers remain valid; reverting or avoiding the new tag restores the previous solver behavior.
